### PR TITLE
Fix build of the web app

### DIFF
--- a/cmd/alpacascloud/web/package.json
+++ b/cmd/alpacascloud/web/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "license": "MIT",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "vite build",
     "serve": "vite"

--- a/cmd/alpacascloud/web/vite.config.ts
+++ b/cmd/alpacascloud/web/vite.config.ts
@@ -2,6 +2,14 @@ import {defineConfig} from 'vite'
 import copy from "rollup-plugin-copy";
 
 export default defineConfig({
+    build: {
+        commonjsOptions: {
+            include: []
+        }
+    },
+    optimizeDeps: {
+        disabled: false,
+    },
     plugins: [
         copy({
             targets: [{src: "openapi.json", dest: "dist/"}],


### PR DESCRIPTION
ESBuild deps optimization is used at build time [0] which appears to fix the build of Swagger.

[0] https://vitejs.dev/guide/migration.html#using-esbuild-deps-optimization-at-build-time